### PR TITLE
Solve issues with make on Ubuntu 20.04

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ TARGETS = nspire.o dir.o file.o stat.o
 all: nspire
 
 nspire: $(TARGETS)
-	$(CC) -o $@ $(LIBS) $(CFLAGS) $^
+	$(CC) -o $@ $(CFLAGS) $^ $(LIBS)
 
 clean:
 	rm -f $(TARGETS) *.o


### PR DESCRIPTION
The functions in fuse weren't found, I found this fix at https://stackoverflow.com/questions/22288456/fuse-functions-not-found-on-compile/22290534#22290534